### PR TITLE
Make version updating easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wheels/
 node_modules/
 widgyts/static/
 js/package-lock.json
+js/yarn.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/js/lib/colormaps.js
+++ b/js/lib/colormaps.js
@@ -2,6 +2,7 @@ var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var _yt_tools = import('@data-exp-lab/yt-tools');
 var _ = require('lodash');
+var EXTENSION_VERSION = require('../package.json').version
 
 var CMapModel = widgets.WidgetModel.extend({
 
@@ -9,7 +10,7 @@ var CMapModel = widgets.WidgetModel.extend({
         return _.extend(widgets.WidgetModel.prototype.defaults.call(this), {
             _model_name: 'CMapModel',
             _model_module: '@data-exp-lab/yt-widgets',
-            _model_module_version: '0.3.1',
+            _model_module_version: EXTENSION_VERSION,
 
             cmaps: undefined,
             map_name: null,
@@ -114,7 +115,7 @@ var CMapModel = widgets.WidgetModel.extend({
 }, {
     model_module: '@data-exp-lab/yt-widgets',
     model_name: 'CMapModel',
-    model_module_version: '0.3.1',
+    model_module_version: EXTENSION_VERSION,
 });
 
 module.exports = {

--- a/js/lib/fixed_res_buffer.js
+++ b/js/lib/fixed_res_buffer.js
@@ -2,6 +2,7 @@ var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var _yt_tools = import('@data-exp-lab/yt-tools');
 var _ = require('lodash');
+var EXTENSION_VERSION = require('../package.json').version
 
 var FRBModel = widgets.DOMWidgetModel.extend({
     defaults: _.extend({}, widgets.DOMWidgetModel.prototype.defaults, {
@@ -9,8 +10,8 @@ var FRBModel = widgets.DOMWidgetModel.extend({
         _view_name : 'FRBView',
         _model_module : '@data-exp-lab/yt-widgets',
         _view_module : '@data-exp-lab/yt-widgets',
-        _model_module_version : '0.3.1',
-        _view_module_version : '0.3.1',
+        _model_module_version : EXTENSION_VERSION,
+        _view_module_version : EXTENSION_VERSION,
         px: undefined,
         py: undefined,
         pdx: undefined,

--- a/js/lib/image_canvas.js
+++ b/js/lib/image_canvas.js
@@ -1,8 +1,9 @@
 var widgets = require('@jupyter-widgets/base');
 var ipydatawidgets = require('jupyter-dataserializers');
 var frb = require('./fixed_res_buffer.js');
-var cmaps = require('./colormaps.js')
+var cmaps = require('./colormaps.js');
 var _ = require('lodash');
+var EXTENSION_VERSION = require('../package.json').version
 
 // Custom Model. Custom widgets models must at least provide default values
 // for model attributes, including
@@ -25,8 +26,8 @@ var ImageCanvasModel = widgets.DOMWidgetModel.extend({
         _view_name : 'ImageCanvasView',
         _model_module : '@data-exp-lab/yt-widgets',
         _view_module : '@data-exp-lab/yt-widgets',
-        _model_module_version : '0.3.1',
-        _view_module_version : '0.3.1',
+        _model_module_version : EXTENSION_VERSION,
+        _view_module_version : EXTENSION_VERSION,
         image_array: undefined,
         width: 256,
         height: 256

--- a/widgyts/_version.py
+++ b/widgyts/_version.py
@@ -5,3 +5,5 @@ _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': '',
 
 __version__ = '%s.%s.%s%s'%(version_info[0], version_info[1], version_info[2],
   '' if version_info[3]=='final' else _specifier_[version_info[3]]+str(version_info[4]))
+
+EXTENSION_VERSION='~0.3.1'

--- a/widgyts/colormaps/colormaps.py
+++ b/widgyts/colormaps/colormaps.py
@@ -3,6 +3,7 @@ from ipydatawidgets import DataUnion, shape_constraints, \
         data_union_serialization
 import numpy as np
 import traitlets
+from .._version import EXTENSION_VERSION
 
 rgba_image_shape = shape_constraints(None, None, 4)
 vmesh_shape = shape_constraints(None)
@@ -14,7 +15,7 @@ class ColorMaps(ipywidgets.Widget):
 
     _model_name = traitlets.Unicode('CMapModel').tag(sync=True)
     _model_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)
-    _model_module_version = traitlets.Unicode('^0.3.1').tag(sync=True)
+    _model_module_version = traitlets.Unicode(EXTENSION_VERSION).tag(sync=True)
 
     cmaps = traitlets.Dict({}).tag(sync=True, config=True)
     map_name = traitlets.Unicode('autumn').tag(sync=True, config=True)

--- a/widgyts/image_canvas.py
+++ b/widgyts/image_canvas.py
@@ -15,6 +15,7 @@ from yt.visualization.fixed_resolution import \
         FixedResolutionBuffer as frb
 from yt.funcs import \
         ensure_list
+from ._version import EXTENSION_VERSION
 
 rgba_image_shape = shape_constraints(None, None, 4)
 vmesh_shape = shape_constraints(None)
@@ -26,8 +27,8 @@ class ImageCanvas(ipywidgets.DOMWidget):
     _model_name = traitlets.Unicode('ImageCanvasModel').tag(sync=True)
     _view_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)
     _model_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)
-    _view_module_version = traitlets.Unicode('^0.3.1').tag(sync=True)
-    _model_module_version = traitlets.Unicode('^0.3.1').tag(sync=True)
+    _view_module_version = traitlets.Unicode(EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = traitlets.Unicode(EXTENSION_VERSION).tag(sync=True)
     image_array = DataUnion(dtype=np.uint8,
             shape_constraint=rgba_image_shape).tag(sync=True,
                     **data_union_serialization)
@@ -41,8 +42,8 @@ class FRBViewer(ipywidgets.DOMWidget):
     _model_name = traitlets.Unicode('FRBModel').tag(sync=True)
     _view_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)
     _model_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)
-    _view_module_version = traitlets.Unicode('^0.3.1').tag(sync=True)
-    _model_module_version = traitlets.Unicode('^0.3.1').tag(sync=True)
+    _view_module_version = traitlets.Unicode(EXTENSION_VERSION).tag(sync=True)
+    _model_module_version = traitlets.Unicode(EXTENSION_VERSION).tag(sync=True)
     width = traitlets.Int(512).tag(sync=True)
     height = traitlets.Int(512).tag(sync=True)
     px = DataUnion(dtype=np.float64,


### PR DESCRIPTION
Currently when we do a release and bump up the version we need to modify the version numbering manually in all of all of our model modules and view modules. This makes that a little easier by pulling in a version from the _version.py file (which is modified in the release process anyways) on the python side and from package.json on the js side. Only these two files should need to be modified for future version updates. 

I've also added yarn.lock to gitignore now that we've added jupyter lab support. 