### PR TITLE
update example notebook to include details on data source 

### DIFF
--- a/examples/galaxy_display.ipynb
+++ b/examples/galaxy_display.ipynb
@@ -22,6 +22,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "yt has several example datasets (and a number of tutorials on reading and analyzing its data) that are available on [its webpage](http://yt-project.org/data/). This tutorial will use the IsolatedGalaxy dataset. If you do not have IsoaltedGalaxy on your machine, please download and unzip it from http://yt-project.org/data/IsolatedGalaxy.tar.gz. \n",
+    "\n",
+    "yt's load function searches a for a user-configurable datapath (in addition to the current working directory). If you'd like to learn more about setting up your datapath for yt so that you can store your data centrally, see the documentation on configuring the `test_data_dir` on [this page](http://yt-project.org/doc/reference/configuration.html#available-configuration-options). The next cell loads IsolatedGalaxy as if it is in the `test_data_dir folder`. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -29,17 +38,11 @@
    },
    "outputs": [],
    "source": [
-    "ds = yt.load(\"data/IsolatedGalaxy/galaxy0030/galaxy0030\")\n",
+    "ds = yt.load(\"IsolatedGalaxy/galaxy0030/galaxy0030\")\n",
     "s = ds.r[:,:,0.5]\n",
-    "s.display(\"density\")"
+    "ss = s.display(\"density\")\n",
+    "ss"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -58,7 +61,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses data-exp-lab/widgyts#32 

I've added a cell to the example notebook that mentions IsolatedGalaxy and links to the yt data page. I've also linked to the page on setting the `test_data_dir` in yt's configuration options, so it's clear that users can store their data in a central location a bit easier. 

I've also opened an issue to create a new notebook data-exp-lab/widgyts#33 that shows the trait linking of canvases. We can further expand our examples to make widgyts more accessible. 