### PR TITLE
fix typo in galaxy display notebook

### DIFF
--- a/examples/galaxy_display.ipynb
+++ b/examples/galaxy_display.ipynb
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "yt has several example datasets (and a number of tutorials on reading and analyzing its data) that are available on [its webpage](http://yt-project.org/data/). This tutorial will use the IsolatedGalaxy dataset. If you do not have IsoaltedGalaxy on your machine, please download and unzip it from http://yt-project.org/data/IsolatedGalaxy.tar.gz. \n",
+    "yt has several example datasets (and a number of tutorials on reading and analyzing its data) that are available on [its webpage](http://yt-project.org/data/). This example will use the IsolatedGalaxy dataset. If you do not have IsolatedGalaxy on your machine, please download and unzip it from http://yt-project.org/data/IsolatedGalaxy.tar.gz. \n",
     "\n",
     "yt's load function searches a for a user-configurable datapath (in addition to the current working directory). If you'd like to learn more about setting up your datapath for yt so that you can store your data centrally, see the documentation on configuring the `test_data_dir` on [this page](http://yt-project.org/doc/reference/configuration.html#available-configuration-options). The next cell loads IsolatedGalaxy as if it is in the `test_data_dir folder`. "
    ]


### PR DESCRIPTION
Brought up in data-exp-lab/widgyts#32. I also changed the wording in this cell from "tutorial" to "example", since the latter describes the intent of this notebook better. 