### PR TITLE
create sphinx documentation for widgyts

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -88,7 +88,9 @@ a development build of widgyts on your personal machine. To build the
 documentation, we have opted to use the same method as `ipywidgets
 <https://ipywidgets.readthedocs.io/en/stable/dev_docs.html>`_ and distribute an
 ``environment.yml`` file that can be used to create an environment with the
-necessary packages to build the documentation on your personal machine. 
+necessary packages to build the documentation on your personal machine.
+However, there's no need to create an additional environment if you already
+have the environment to build the ipywidgets docs. 
 
 To install a widgyts docs environment with conda::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,133 @@
+############
+Contributing
+############
+
+We welcome and encourage new contributors to this project! We're happy to help
+you work through any issues you're having or to help you contribute to the
+project, so please reach out if you're interested. 
+
+.. important::
+   We want your help. No, really.
+
+   There may be a little voice inside your head that is telling you that you're
+   not ready to be an open source contributor; that your skills aren't nearly good
+   enough to contribute. What could you possibly offer a project like this one?
+   
+   We assure you - the little voice in your head is wrong. If you can write code
+   at all, you can contribute code to open source. Contributing to open source
+   projects is a fantastic way to advance one's coding skills. Writing perfect
+   code isn't the measure of a good developer (that would disqualify all of us!);
+   it's trying to create something, making mistakes, and learning from those
+   mistakes. That's how we all improve, and we are happy to help others learn.
+   
+   Being an open source contributor doesn't just mean writing code, either. You
+   can help out by writing documentation, tests, or even giving feedback about the
+   project (and yes - that includes giving feedback about the contribution
+   process). Some of these contributions may be the most valuable to the project
+   as a whole, because you're coming to the project with fresh eyes, so you can
+   see the errors and assumptions that seasoned contributors have glossed over.
+
+Issues, Bugs, and New Feature Suggestions
+-----------------------------------------
+
+If you have
+suggestions on new features, improvements to the project itself, you've
+detected some unruly behavior or a bug, or a suggestion of how we can
+make the project more accessible, feel free to file an `issue on
+github <https://github.com/data-exp-lab/widgyts/issues)>`_. 
+
+Communication Channels
+----------------------
+
+If you need help or have any questions about using widgyts that's beyond the
+documentation (or if you'd like to join our community), you're welcome to
+join the `yt project's slack <https://yt-project.org/slack.html>`_ (specifically in the widgyts channel) 
+or ask in the `yt users mailing list
+<https://mail.python.org/mailman3/lists/yt-users.python.org/>`_.
+
+If you'd like to talk about new features or development of widgyts, the widyts
+channel in the `yt project's slack <https://yt-project.org/slack.html>`_ is a
+good place to go. The `yt development mailing list 
+<https://mail.python.org/mailman3/lists/yt-dev.python.org/>`_ is channel where
+these discussions are welcomed. 
+
+Contributing Code
+-----------------
+
+We would be delighted for you to join and work on the widgyts project! If
+you're interested in getting started, browse some of our `open issues
+<https://github.com/data-exp-lab/widgyts/issues>`_ and see if there's anything
+that you may find interesting. If there's a new feature you'd like to add that
+isn't in open issues, please reach out in the `widgyts slack channel in the yt
+slack <https://yt-project.org/slack.html>`_ or on the `yt development mailing 
+list <https://mail.python.org/mailman3/lists/yt-dev.python.org/>`_ to talk a 
+bit more about
+what you'd like to contribute. This will help make your contribution review go
+smoothly and merge quickly!
+
+To get a development environment set up on your machine, please see the
+:ref:`development_install` directions to get started. 
+
+When issuing a pull request for new features in the widgyts package, please 
+make sure the following are satisfied:
+
+- new features have accompanying documentation, including docstrings and
+  examples
+- if javascript functionality is added, ensure it is commented thoroughly
+- tests have been added for new features
+- all tests run and pass
+- new documentation satisfies documentation contribution requirements
+
+.. _building_the_documentation:
+
+Contributing Examples or Documentation
+--------------------------------------
+
+To contribute new examples or update the documentation you do not need to have
+a development build of widgyts on your personal machine. To build the
+documentation, we have opted to use the same method as `ipywidgets
+<https://ipywidgets.readthedocs.io/en/stable/dev_docs.html>`_ and distribute an
+``environment.yml`` file that can be used to create an environment with the
+necessary packages to build the documentation on your personal machine. 
+
+To install a widgyts docs environment with conda::
+
+  $ conda env create -f docs/environment.yml
+
+and then to activate it::
+
+  $ source activate widgyts_docs
+
+Once the packages necessary to build the documentation are installed on your
+machine, navigate into the documentation folder and use the Makefile to build
+the documentation::
+
+  $ cd docs
+  $ make clean
+  $ make html
+
+The documentation will be built in the ``build/html`` folder.  
+
+When issuing a pull request for additional documentation or new examples, please 
+make sure the following are satisfied:
+
+- new links, references, and pages work as expected
+- the documentation renders locally 
+- trivializing words like "just", "simply" or "trivial" are used minimally
+- if contributing a notebook, ensure that the data source is clearly documented 
+- if contributing a notebook, please ensure that each cell has a preamble
+  or comment explaining the contents of the next cell to be executed 
+
+Code Review and Expectations
+-----------------------------
+
+After you submit a PR with your contribution, you can expect maintainers of the
+project to begin review within a week. 
+
+Please keep in mind
+that this project is fairly new, so we will try to get back to you as soon as
+possible with any contributions, but it may take a few days. 
+
+.. note::
+   We expect members of this community to abide by the :doc:`Code of Conduct
+   <code_of_conduct>` when interacting in this community. 

--- a/CoC.rst
+++ b/CoC.rst
@@ -1,0 +1,78 @@
+.. _code_of_conduct:
+
+###############
+Code of Conduct
+###############
+
+.. note::
+   Widgyts is a project associated with yt, so we have decided to adapt the yt
+   project code of conduct. The yt project code of conduct was adapted from the
+   `Astropy Community Code of Conduct
+   <http://www.astropy.org/code_of_conduct.html>`_, which was partially adapted
+   by the PSF code of conduct. 
+
+The community of participants in open source
+Scientific projects is made up of members from around the
+globe with a diverse set of skills, personalities, and
+experiences. It is through these differences that our
+community experiences success and continued growth. We
+expect everyone in our community to follow these guidelines
+when interacting with others both inside and outside of our
+community. Our goal is to keep ours a positive, inclusive,
+successful, and growing community.
+
+As members of the community,
+
+- We pledge to treat all people with respect and
+  provide a harassment- and bullying-free environment,
+  regardless of sex, sexual orientation and/or gender
+  identity, disability, physical appearance, body size,
+  race, nationality, ethnicity, and religion. In
+  particular, sexual language and imagery, sexist,
+  racist, or otherwise exclusionary jokes are not
+  appropriate.
+
+- We pledge to respect the work of others by
+  recognizing acknowledgment/citation requests of
+  original authors. As authors, we pledge to be explicit
+  about how we want our own work to be cited or
+  acknowledged.
+
+- We pledge to welcome those interested in joining the
+  community, and realize that including people with a
+  variety of opinions and backgrounds will only serve to
+  enrich our community. In particular, discussions
+  relating to pros/cons of various technologies,
+  programming languages, and so on are welcome, but
+  these should be done with respect, taking proactive
+  measure to ensure that all participants are heard and
+  feel confident that they can freely express their
+  opinions.
+
+- We pledge to welcome questions and answer them
+  respectfully, paying particular attention to those new
+  to the community. We pledge to provide respectful
+  criticisms and feedback in forums, especially in
+  discussion threads resulting from code
+  contributions.
+
+- We pledge to be conscientious of the perceptions of
+  the wider community and to respond to criticism
+  respectfully. We will strive to model behaviors that
+  encourage productive debate and disagreement, both
+  within our community and where we are criticized. We
+  will treat those outside our community with the same
+  respect as people within our community.
+
+- We pledge to help the entire community follow the
+  code of conduct, and to not remain silent when we see
+  violations of the code of conduct. We will take action
+  when members of our community violate this code such as
+  contacting confidential@yt-project.org (all emails sent to
+  this address will be treated with the strictest
+  confidence) or talking privately with the person.
+
+This code of conduct applies to all
+community situations online and offline, including mailing
+lists, forums, social media, conferences, meetings,
+associated social events, and one-to-one interactions.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,22 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SPHINXPROJ    = widgyts
+SOURCEDIR     = source
+BUILDDIR      = build
+REPODIR       = ../../widgyts_docs
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,7 +8,6 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = widgyts
 SOURCEDIR     = source
 BUILDDIR      = build
-REPODIR       = ../../widgyts_docs
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,18 @@
+name: widgyts_docs
+channels:
+- conda-forge
+- defaults
+dependencies:
+- ipykernel
+- jinja2
+- jupyter_sphinx
+- ipywidgets
+- nbformat
+- nbsphinx
+- notebook>=4.2
+- python=3.6
+- sphinx>=1.4.6
+- sphinx_rtd_theme
+- tornado
+- python-dateutil
+- recommonmark

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/code_of_conduct.rst
+++ b/docs/source/code_of_conduct.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CoC.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,70 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+if not on_rtd:
+    import sphinx_rtd_theme
+    html_theme = "sphinx_rtd_theme"
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'widgyts'
+copyright = '2019, Madicken Munk, Matthew Turk'
+author = 'Madicken Munk, Matthew Turk'
+
+# The full version, including alpha/beta/rc tags
+# release = '0.3.1'
+
+_release = {}
+exec(compile(open('../../widgyts/_version.py').read(), '../../widgyts/_version.py', 'exec'), _release)
+# version = '.'.join(map(str, _release['version_info'][:2]))
+version = '.'.join(map(str, _release['version_info']))
+release = _release['__version__']
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    'nbsphinx',
+    'jupyter_sphinx.embed_widgets',
+    'IPython.sphinxext.ipython_console_highlighting',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../../CONTRIBUTING.rst

--- a/docs/source/developer_guide.rst
+++ b/docs/source/developer_guide.rst
@@ -1,0 +1,23 @@
+.. _developer_guide:
+
+###############
+Developer Guide
+###############
+
+Getting A Development Build of Widgyts
+--------------------------------------
+
+To get a development build of ``widgyts`` on your machine, refer to the
+:ref:`development_install` instructions.
+
+Building the Docs
+-----------------
+
+To build the documentation locally, refer to the instructions in the
+:ref:`building_the_documentation` section. 
+
+Testing
+-------
+
+Releasing
+---------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,26 @@
+.. _getting_started:
+
+Getting Started
+===============
+
+The widgyts package is designed to work with yt, but it can also work without
+a yt import. 
+
+Components of widgyts
+---------------------
+
+Presently widgyts has three widgets that a user can interact with:
+``ImageCanvas``, ``FRBViewer``, and ``ColorMaps``. Each widget has a number of
+traitlets that sync back to the javascript (and potentially webassembly) that
+can be updated through the widget API. These traitlets can be linked (see our
+example notebooks for some demonstrations of this in practice) so that widget 
+instances can update together. 
+
+API Documentation
+-----------------
+
+.. autoclass:: widgyts.ImageCanvas
+.. autoclass:: widgyts.FRBViewer
+.. autofunction:: widgyts.FRBViewer.setup_controls
+.. autofunction:: widgyts.FRBViewer.display_yt
+.. autoclass:: widgyts.ColorMaps

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -13,7 +13,7 @@ Presently widgyts has three widgets that a user can interact with:
 ``ImageCanvas``, ``FRBViewer``, and ``ColorMaps``. Each widget has a number of
 traitlets that sync back to the javascript (and potentially webassembly) that
 can be updated through the widget API. These traitlets can be linked (see our
-example notebooks for some demonstrations of this in practice) so that widget 
+:ref:`examples` for some demonstrations of this in practice) so that widget 
 instances can update together. 
 
 API Documentation
@@ -22,5 +22,17 @@ API Documentation
 .. autoclass:: widgyts.ImageCanvas
 .. autoclass:: widgyts.FRBViewer
 .. autofunction:: widgyts.FRBViewer.setup_controls
-.. autofunction:: widgyts.FRBViewer.display_yt
+.. autofunction:: widgyts.display_yt
 .. autoclass:: widgyts.ColorMaps
+
+.. _examples:
+
+.. include:: ../../examples/README.rst
+
+
+Links:
+
+- link to `galaxy display notebook
+  <https://github.com/data-exp-lab/widgyts/blob/master/examples/galaxy_display.ipynb>`_
+- link to `FRBViewer tutorial notebook
+  <https://github.com/data-exp-lab/widgyts/blob/master/examples/FRBViewer_tutorial.ipynb>`_

--- a/docs/source/help.rst
+++ b/docs/source/help.rst
@@ -1,0 +1,25 @@
+.. _help:
+
+############
+Getting Help
+############
+
+Do not hesitate to reach out through one of our numerous communication channels
+should you need help with anything widgyts-related. 
+
+Communication Channels
+----------------------
+
+If you need help or have any questions about using widgyts that's beyond the
+documentation (or if you'd like to join our community), you're welcome to
+join the `yt project's slack <https://yt-project.org/slack.html>`_ (specifically in the widgyts channel) 
+or ask in the `yt users mailing list
+<https://mail.python.org/mailman3/lists/yt-users.python.org/>`_.
+
+If you'd like to talk about new features or development of widgyts, or if you
+need some assistance developing in the widgyts project, the widyts
+channel in the `yt project's slack <https://yt-project.org/slack.html>`_ is a
+good place to go. The `yt development mailing list 
+<https://mail.python.org/mailman3/lists/yt-dev.python.org/>`_ is channel where
+these discussions are also welcomed. 
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,9 +6,19 @@
 Welcome to widgyts's documentation!
 ===================================
 
+widgyts is a package built on jupyter widgets intended to aid in fast,
+interactive, exploratory visualization of data. If you have a dataset you'd
+like to explore but aren't completely sure about what parameters need to be
+tuned to make the visualization that best representes your data, widgyts is the
+package for you! widgyts has been designed to work as a companion to `yt
+<https://yt-project.org/>`_, but it is also flexible and can handle any
+mesh-based data.  
+
 widyts is a fully client-side pan-and-zoom widget, using WebAssembly, for variable mesh
 datasets from yt.  It runs in the browser, so once the data hits your notebook,
-it's super fast and responsive!
+it's super fast and responsive! This will allow you to quickly update your
+visualization to figure out how best to illustrate the interesting aspects of
+your data. 
 
 If you'd like to dig into the Rust and WebAssembly portion of the code, you can
 find it at `Github <https://github.com/data-exp-lab/rust-yt-tools/>`_ and in the npm

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. widgyts documentation master file, created by
+   sphinx-quickstart on Thu Jun  6 11:14:51 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to widgyts's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,6 @@ and the `associated slides <https://munkm.github.io/2018-07-13-scipy/>`_ for mor
    :maxdepth: 2
    :caption: Table of Contents:
    
-   overview
    install
    getting_started
    contributing

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,9 +6,28 @@
 Welcome to widgyts's documentation!
 ===================================
 
+widyts is a fully client-side pan-and-zoom widget, using WebAssembly, for variable mesh
+datasets from yt.  It runs in the browser, so once the data hits your notebook,
+it's super fast and responsive!
+
+If you'd like to dig into the Rust and WebAssembly portion of the code, you can
+find it at `Github <https://github.com/data-exp-lab/rust-yt-tools/>`_ and in the npm
+package `@data-exp-lab/yt-tools`.
+
+Check out our `SciPy 2018 talk <https://www.youtube.com/watch?v=5dl_m_6T2bU>`_
+and the `associated slides <https://munkm.github.io/2018-07-13-scipy/>`_ for more info!
+
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Table of Contents:
+   
+   overview
+   install
+   getting_started
+   contributing
+   developer_guide
+   code_of_conduct
+   help
 
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,0 +1,81 @@
+.. _installation:
+
+############
+Installation
+############
+
+Dependencies
+------------
+
+The widgyts project depends on a number of packages. Minimally, your machine
+should have ``ipywidgets``, ``ipydatawidgets`` and ``yt``. 
+
+For a development version, you will also be required to install `npm
+<https://www.npmjs.com/>`_ and `node.js <https://nodejs.org/en/>`_ to manage
+the javascript code and associated dependencies. Due to the
+proliferation of the jupyter widgets ecosystem, these are available to install 
+with conda. 
+
+PyPI Installation (recommended)
+-------------------------------
+
+``widgyts`` is packaged and available on the `Python Package Index
+<https://pypi.org/project/widgyts/>`_. You can install ``widgyts`` from pypi by
+executing::
+
+  $ pip install widgyts
+
+Note that if you do not already have jupyter widgets or jupyter datawidgets
+installed on your machine or in your current active environment, 
+this step may take some time. 
+
+Installation from Source
+------------------------
+
+To install ``widgyts`` from source, you'll need to clone the repository from
+`Github <https://github.com/data-exp-lab/widgyts>`_::
+
+  $ git clone https://github.com/data-exp-lab/widgyts.git
+
+Then navigate into the newly created directory and install using pip::
+
+  $ cd widgyts
+  $ pip install .
+
+.. _development_install:
+  
+Development Installation 
+------------------------
+
+For a development installation your machine will need npm to manage the
+associated javascript code and dependencies. :: 
+
+  $ git clone https://github.com/data-exp-lab/widgyts.git
+  $ cd widgyts/js
+  $ npm install 
+  $ cd ../
+  $ pip install -e .
+  $ jupyter serverextension enable --py --sys-prefix widgyts
+  $ jupyter nbextension install --py --symlink --sys-prefix widgyts
+  $ jupyter nbextension enable --py --sys-prefix widgyts
+
+If you are modifying code on the python side, you may have to periodically
+update your installation from the steps ``pip install`` onwards. If you are
+modifying javascript code, you'll need to rerun ``npm install`` to have your
+changes available in jupyter notebooks.
+
+Note that in previous versions, serverextension was not provided and you were
+required to set up your own mimetype in your local configuration.  This is no
+longer the case and you are now able to use this server extension to set up the
+correct wasm mimetype.
+
+To install the jupyterlab extension, you will need to make sure you are on a
+recent enough version of Jupyterlab, preferably 0.35 or above.  For a
+development installation, do: ::
+
+    $ jupyter labextension install js
+
+To install the latest released version, :: 
+
+    $ jupyter labextension install @data-exp-lab/yt-widgets
+

--- a/examples/FRBViewer_tutorial.ipynb
+++ b/examples/FRBViewer_tutorial.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interacting with the FRBViewer widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This widget ports the functionality of the yt pixelization function to Rust, and then to WebAssembly, so that the actual change in the image is conducted in the browser. Once the display has been created, no further contact with the server is necessary to get new data! It will pass some info back and forth (such as bounds and the like) but all of the actual visualization is occuring locally, in the browser, and is thus much faster with lower latency.\n",
+    "\n",
+    "It may appear blank at first, in which case you will need to toggle one of the viewable parameters, such as the colormap log scaling, to ensure an image appears.\n",
+    "\n",
+    "First, let's import our necessary modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yt\n",
+    "import widgyts\n",
+    "import ipywidgets "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's use yt to load in some data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = yt.load(\"enzo_tiny_cosmology/DD0046/DD0046\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slices and Projections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll take a slice of our dataset and pass that slice into the FRBViewer widget from widgyts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# making the slice\n",
+    "s = ds.r[:,:,0.5]\n",
+    "\n",
+    "# putting data into a FRBViewer (loading the data into wasm)\n",
+    "frb_dens = widgyts.FRBViewer(height = 512, width = 512,\n",
+    "                            px = s[\"px\"], py = s[\"py\"], pdx = s[\"pdx\"], pdy = s[\"pdy\"],\n",
+    "                            val = s[\"density\"],\n",
+    "                            layout = ipywidgets.Layout(width = '500px', height='500px'))\n",
+    "\n",
+    "#using the default controls menu\n",
+    "controls = frb_dens.setup_controls()\n",
+    "display(ipywidgets.HBox([controls,frb_dens]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, we can use the `proj(field, axis)` operation on the dataset to get a projection object of the density projected on the z axis and pass that to the FRB. \n",
+    "\n",
+    "**note**: to see this image, you'll want to go into the colormap dropdown and set the log scale of the colorbar. You can zoom in or out on the image as well. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = ds.proj(\"density\", \"z\")\n",
+    "\n",
+    "frb_proj_dens = widgyts.FRBViewer(height = 512, width = 512,\n",
+    "                            px = m[\"px\"], py = m[\"py\"], pdx = m[\"pdx\"], pdy = m[\"pdy\"],\n",
+    "                            val = m[\"density\"],\n",
+    "                            layout = ipywidgets.Layout(width = '500px', height='500px'))\n",
+    "\n",
+    "#using the default controls menu\n",
+    "controls = frb_proj_dens.setup_controls()\n",
+    "display(ipywidgets.HBox([controls,frb_proj_dens]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Updating the Traitlets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Traitlets in the colormap widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The API documentation for widgyts details a bit about the traitlets that each widget has. The control panel on the left side of these earlier visualizations directly interact with some of those traitlets. You can use the controls to update these values, but you can also modify them directly. \n",
+    "\n",
+    "This next cell will update the density projection image's colormap to inferno, change the scale to log if it isn't already, and also update teh colormap bounds (the min and max value defaults for this dataset are ~1.3e-05 and 5.6e-02, respectively).\n",
+    "\n",
+    "Note that the traitlets in this cell belong to the colormaps class. All colormap-related traitlets are handled by the Colormap widget. A few cells down we can also see some examples of updating traitlets that belong to the FRBViewer widget. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frb_proj_dens.colormaps.map_name='inferno'\n",
+    "frb_proj_dens.colormaps.is_log=True\n",
+    "frb_proj_dens.colormaps.min_val=1.2e-05\n",
+    "frb_proj_dens.colormaps.max_val=5.0e-02\n",
+    "\n",
+    "\n",
+    "display(frb_proj_dens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note here that the display of the frb_proj_dens updated in this cell and the previous cell with the navigation panel. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Linking views with traitlets "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Updating traitlets directly is helpful in many ways. We can also use ipywidgets traitlet linking to make two views sync together. First, let's make another projection, but this time with temperature. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = ds.proj(\"temperature\", \"z\")\n",
+    "\n",
+    "frb_proj_temp = widgyts.FRBViewer(height = 512, width = 512,\n",
+    "                            px = n[\"px\"], py = n[\"py\"], pdx = n[\"pdx\"], pdy = n[\"pdy\"],\n",
+    "                            val = n[\"temperature\"],\n",
+    "                            layout = ipywidgets.Layout(width = '500px', height='500px'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's link the traitlets between the density and temperature projections and set the temperature colormap to be something different from density "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipywidgets.link((frb_proj_dens, 'view_center'), (frb_proj_temp, 'view_center'))\n",
+    "ipywidgets.link((frb_proj_dens, 'view_width'), (frb_proj_temp, 'view_width'))\n",
+    "ipywidgets.link((frb_proj_dens.colormaps, 'is_log'), (frb_proj_temp.colormaps, 'is_log'))\n",
+    "\n",
+    "frb_proj_temp.colormaps.map_name='magma'\n",
+    "frb_proj_temp.colormaps.min_val=1.59e+29\n",
+    "frb_proj_temp.colormaps.max_val=1.125e+32"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's set up a view with a control panel and both the temperature and projection views.\n",
+    "\n",
+    "If you update aspects of the view parameters of the density plot, the temperature plot will update in the same manner. Try and click within either of the images to re-center it, or use the zoom button to see interesting features of either map. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "controls = frb_proj_dens.setup_controls()\n",
+    "display(ipywidgets.HBox([controls,frb_proj_dens,frb_proj_temp]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note here that the control panel is linked to the density projection plot, but you can still update the temperature plot using the traitlets. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "frb_proj_temp.colormaps.map_name='inferno'"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,14 @@
+Examples
+========
+
+The example notebooks illustrate different functionality of the widgyts
+package. Each is intended to show how widgyts can be used for your own
+workflow. 
+
+- ``galaxy_display.ipynb`` shows the monkeypatching feature between yt and
+  widgyts to enable you to do interactive visualization directly on any yt
+  dataset. 
+- ``FRBViewer_tutorial.ipynb`` shows using the FRBViewer module of widgyts in
+  conjunction with yt's data manipulation features. It illustrates some
+  traitlet manipulation in the Colormaps module as well as traitlet linking
+  between views of different fields. 

--- a/widgyts/image_canvas.py
+++ b/widgyts/image_canvas.py
@@ -37,7 +37,58 @@ class ImageCanvas(ipywidgets.DOMWidget):
 
 @ipywidgets.register
 class FRBViewer(ipywidgets.DOMWidget):
-    """Viewing a fixed resolution buffer"""
+    """View of a fixed resolution buffer.
+
+    FRBViewer(width, height, px, py, pdx, pdy, val)
+
+    This widget creates a view of a fixed resolution buffer of
+    size (`width`, `height`) given data variables `px`, `py`, `pdx`, `pdy`,
+    and val. Updates on the view of the fixed reolution buffer can be made
+    by modifying traitlets `view_center`, `view_width`, or `Colormaps`
+
+    Parameters
+    ----------
+
+    width : integer
+        The width of the fixed resolution buffer output, in pixels
+    height : integer
+        The height of the fixed resolution buffer, in pixels
+    px : array of floats
+        x coordinates for the center of each grid box
+    py : array of floats
+        y coordinates for the center of each grid box
+    pdx : array of floats
+        Values of the half-widths for each grid box
+    pdy : array of floats
+        Values of the half-heights for each grid box
+    val : array of floats
+        Data values for each grid box
+        The data values to be visualized in the fixed resolution buffer.
+    colormaps : :class: `widgyts.Colormaps`
+        This is the widgyt that controls traitlets associated with the
+        colormap.
+    view_center : tuple
+        This is a length two tuple that represents the normalized center of
+        the resulting FRBView.
+    view_width : tuple
+        This is a length two tuple that represents the height and with of the
+        view, normalized to the original size of the image. (0.5, 0.5)
+        represents a view of half the total data with and half the total
+        data height.
+
+    Examples
+    --------
+    To create a fixed resolution buffer view of a density field with this
+    widget, and then to display it:
+
+    >>> ds = yt.load("IsolatedGalaxy")
+    >>> proj = ds.proj("density", "z")
+    >>> frb1 = widgyts.FRBViewer(height=512, width=512, px=proj["px"],
+    ...                          py=proj["py"], pdx=proj["pdx"],
+    ...                          pdy=proj["pdy"], val = proj["density"])
+    >>> display(frb1)
+
+    """
     _view_name = traitlets.Unicode('FRBView').tag(sync=True)
     _model_name = traitlets.Unicode('FRBModel').tag(sync=True)
     _view_module = traitlets.Unicode('@data-exp-lab/yt-widgets').tag(sync=True)


### PR DESCRIPTION
This PR should be v1 of our documentation! Woooo. These docs contain
- contributing guidelines 
- installation instructions for pypi, from source, and development builds
- directions on building the docs locally
- a new example notebook that shows how to use the FRBViewer widget with yt but without the monkeypatching. It also shows the traitlet linking
- basic API documentation
- a code of conduct (with attribution on the lineage of this documentation)

Other notes:
- the testing page is a placeholder. This will be filled out once the test suite is created/built

This PR resolves data-exp-lab/widgyts#33 and data-exp-lab/widgyts#37. However, some of the checkboxes on 37 are minimally-solved. The docstrings need to be updated so that the API docs for autodoc are a bit nicer. Also it would be nice to eventually update our docs so the notebooks render in the documentation with jupyter sphinx. 