### PR TITLE
Remove python 3.5 from the tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 dist: xenial
 python:
-    - 3.5
     - 3.6
     - 3.7
 addons: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 python:
     - 3.6
     - 3.7
+    - 3.8
 addons: 
   firefox: latest
 cache: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 install:
     - pip install pytest pytest-cov 
     - pip install codecov
+    - pip install -r tests/test_requirements.txt
     - pip install -e .
 
 # Command that runs the tests

--- a/setup.py
+++ b/setup.py
@@ -175,12 +175,10 @@ setup_args = {
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'Topic :: Multimedia :: Graphics',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 }
 

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,0 +1,3 @@
+ipywidgets>=7.0.0
+ipydatawidgets>=3.2.0
+yt

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,4 @@
 ipywidgets>=7.0.0
 ipydatawidgets>=3.2.0
 yt
+matplotlib<=3.1.3


### PR DESCRIPTION
Python 3.5 doesn't work with current pytest-cov.
